### PR TITLE
new functions and sub-modules in `phenoscore` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ___
 
 <details>
   <summary>Benchmarking</summary>
-  <p>&nbsp;</p> 
+  <br>
   
   Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 

--- a/README.md
+++ b/README.md
@@ -95,37 +95,42 @@ Data analysis for CRISPR screens with NGS readouts can be broken down into three
 
 ### Step 1: FASTQ processing
 
-ScreenPro2 has a built-in command line interface (CLI) to process FASTQ files and generate counts.
+<details>
+  <summary>command line interface (CLI)</summary>
+  <br>
+  ScreenPro2 has a built-in command line interface (CLI) to process FASTQ files and generate counts.
 
-```bash
-screenpro guidecounter --help
-```
+  ```bash
+  screenpro guidecounter --help
+  ```
 
-A draft code to process FASTQ files and generate counts for [CRISPRa/i-single-sgRNA-screens](#dcas9-crisprai-single-sgrna-screens) dataset:
+  A draft code to process FASTQ files and generate counts for [CRISPRa/i-single-sgRNA-screens](#dcas9-crisprai-single-sgrna-screens) dataset:
 
-```bash
-screenpro guidecounter
-  --cas-type dCas9
-  --single-guide-design
-  -l <path-to-CRISPR-library-table>
-  -p <path-to-fastq-directory>
-  -s <sample-id-1>,<sample2-id>       # comma-separated list of sample ids, i.e. `<sample_id>.fastq.gz` for single sgRNA screens
-  -o <output-directory>
-  --write-count-matrix
-```
+  ```bash
+  screenpro guidecounter
+    --cas-type dCas9
+    --single-guide-design
+    -l <path-to-CRISPR-library-table>
+    -p <path-to-fastq-directory>
+    -s <sample-id-1>,<sample2-id>       # comma-separated list of sample ids, i.e. `<sample_id>.fastq.gz` for single sgRNA screens
+    -o <output-directory>
+    --write-count-matrix
+  ```
 
-A draft code to process FASTQ files and generate counts for [CRISPRa/i-dual-sgRNA-screens](#dcas9-crisprai-dual-sgrna-screens) dataset:
-  
-```bash
-screenpro guidecounter
-  --cas-type dCas9
-  --dual-guide-design
-  -l <path-to-CRISPR-library-table>
-  -p <path-to-fastq-directory>
-  -s <sample-id-1>,<sample2-id>       # comma-separated list of sample ids, i.e. `<sample_id>_R[1,2].fastq.gz` for dual sgRNA screens
-  -o <output-directory>
-  --write-count-matrix
-```
+  A draft code to process FASTQ files and generate counts for [CRISPRa/i-dual-sgRNA-screens](#dcas9-crisprai-dual-sgrna-screens) dataset:
+    
+  ```bash
+  screenpro guidecounter
+    --cas-type dCas9
+    --dual-guide-design
+    -l <path-to-CRISPR-library-table>
+    -p <path-to-fastq-directory>
+    -s <sample-id-1>,<sample2-id>       # comma-separated list of sample ids, i.e. `<sample_id>_R[1,2].fastq.gz` for dual sgRNA screens
+    -o <output-directory>
+    --write-count-matrix
+  ```
+
+</details>
 
 ___
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ___
 
 <details>
   <summary>Benchmarking</summary>
-
+  
   Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 
   ### More thoughtful NGS read trimming recovers more sgRNA counts

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ For example, in a Decitabine CRISPRi drug screen (see Figure 1B-C in [this bioRx
 ##### Flow cytometry based screen workflow: calculate phenotype score to compare high and low bins
 `.calculateFlowBasedScreen` method can be used to calculate the enrichment of each target between high bin vs. low bin 
 of a flow cytometry-based screen experiment. This method calculates `PhenoScore` for each target and adds them to the 
-`.phenotypes` attribute of the `ScreenPro` object.
+`.phenotypes` attribute of the `PooledScreens` object.
 
 ```python
 # Run the ScreenPro2 workflow for CRISPRi-dual-sgRNA-screens
@@ -287,7 +287,7 @@ screen.calculateFlowBasedScreen(
 
 ### Step 3: Data visualization
 
-Once the phenotypes are calculated, you can extract and explore the results using the `.phenotypes` attribute of the `ScreenPro` object. Currently, there are very limited functionalities built-in to visualize the results, but we are working on adding more features to make it easier for users. However, you can easily extract the results and use other libraries like `seaborn` and `matplotlib` in Python or `ggplot2` in R to visualize the results.
+Once the phenotypes are calculated, you can extract and explore the results using the `.phenotypes` attribute of the `PooledScreens` object. Currently, there are very limited functionalities built-in to visualize the results, but we are working on adding more features to make it easier for users. However, you can easily extract the results and use other libraries like `seaborn` and `matplotlib` in Python or `ggplot2` in R to visualize the results.
 
 ___
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ ___
   ```
 
 </details>
+
 ### Step 2: Phenotype calculation
 
 Once you have the counts, you can use ScreenPro2 `phenoscore` and `phenostats` modules to calculate the phenotype scores and statistics between screen arms.

--- a/README.md
+++ b/README.md
@@ -39,19 +39,19 @@ ___
   <summary>Benchmarking</summary>
   <p>
     Benchmarking ScreenPro2 with other CRISPR screen analysis tools
-
-    ### More thoughtful NGS read trimming recovers more sgRNA counts
-
-    ### ScreenPro2 statistical analysis is more accurate than ScreenProcessing
-
-    ### ScreenPro2 is more flexible than ScreenProcessing
-
-    Not only does ScreenPro2 have more features than ScreenProcessing, but it is also more flexible. ScreenPro2 can process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
-
-    ### ScreenPro2 is faster than ScreenProcessing
-
-    Last but not least, ScreenPro2 runs faster than ScreenProcessing (thanks to [biobear](https://github.com/wheretrue/biobear)) for processing FASTQ files.
   </p>
+
+  ### More thoughtful NGS read trimming recovers more sgRNA counts
+
+  ### ScreenPro2 statistical analysis is more accurate than ScreenProcessing
+
+  ### ScreenPro2 is more flexible than ScreenProcessing
+
+  Not only does ScreenPro2 have more features than ScreenProcessing, but it is also more flexible. ScreenPro2 can process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
+
+  ### ScreenPro2 is faster than ScreenProcessing
+
+  Last but not least, ScreenPro2 runs faster than ScreenProcessing (thanks to [biobear](https://github.com/wheretrue/biobear)) for processing FASTQ files.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ ___
 
 <details>
   <summary>Benchmarking</summary>
-  <p>
-    Benchmarking ScreenPro2 with other CRISPR screen analysis tools
-  </p>
+  <div style="margin-top: 20px;"></div>
+  
+  Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 
   ### More thoughtful NGS read trimming recovers more sgRNA counts
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ screenpro --help
 ```
 
 ### Python Package Usage
-First, import the ScreenPro2 package:
+You can also use ScreenPro2 as a Python package. To use ScreenPro2 in your Python code, you can import it as follows:
 
 ```python
 import screenpro as scp

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Data analysis for CRISPR screens with NGS readouts can be broken down into three
 
 ### Step 1: FASTQ processing
 
+The first step in analyzing CRISPR screens with deep sequencing readouts is to process the FASTQ files and generate counts for each guide RNA element in the library. ScreenPro2 has built-in functionalities to process FASTQ files and generate counts for different types of CRISPR screens platforms (see [Supported CRISPR Screen Platforms](#supported-crispr-screen-platforms)).
+
 ___
 
 <details>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ScreenPro2 enables perform flexible analysis on high-content CRISPR screening da
 ___
 <details>
   <summary>Background</summary>
-  <p>&nbsp;</p> 
+  <br>
 
   Functional genomics field is evolving rapidly and many more CRISPR screen platforms are now developed. Therefore, 
   it's important to have a standardized workflow to analyze the data from these screens. ScreenPro2 is provided to 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ScreenPro2 enables perform flexible analysis on high-content CRISPR screening da
 ___
 <details>
   <summary>Background</summary>
+  <p>&nbsp;</p> 
 
   Functional genomics field is evolving rapidly and many more CRISPR screen platforms are now developed. Therefore, 
   it's important to have a standardized workflow to analyze the data from these screens. ScreenPro2 is provided to 
@@ -36,9 +37,8 @@ ___
 ___
 
 <details>
-  <summary>
-    Benchmarking
-  </summary>
+  <summary>Benchmarking</summary>
+  <p>&nbsp;</p> 
   
   Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,22 @@ ___
 
 <details>
   <summary>Benchmarking</summary>
-  
-  Benchmarking ScreenPro2 with other CRISPR screen analysis tools
+  <p>
+    Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 
-  ### More thoughtful NGS read trimming recovers more sgRNA counts
+    ### More thoughtful NGS read trimming recovers more sgRNA counts
 
-  ### ScreenPro2 statistical analysis is more accurate than ScreenProcessing
+    ### ScreenPro2 statistical analysis is more accurate than ScreenProcessing
 
-  ### ScreenPro2 is more flexible than ScreenProcessing
+    ### ScreenPro2 is more flexible than ScreenProcessing
 
-  Not only does ScreenPro2 have more features than ScreenProcessing, but it is also more flexible. ScreenPro2 can process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
+    Not only does ScreenPro2 have more features than ScreenProcessing, but it is also more flexible. ScreenPro2 can process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
 
-  ### ScreenPro2 is faster than ScreenProcessing
+    ### ScreenPro2 is faster than ScreenProcessing
 
-  Last but not least, ScreenPro2 runs faster than ScreenProcessing (thanks to [biobear](https://github.com/wheretrue/biobear)) for processing FASTQ files.
-  
+    Last but not least, ScreenPro2 runs faster than ScreenProcessing (thanks to [biobear](https://github.com/wheretrue/biobear)) for processing FASTQ files.
+  </p>
+
 </details>
 
 ___

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![CodeQL](https://github.com/ArcInstitute/ScreenPro2/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/ArcInstitute/ScreenPro2/actions/workflows/github-code-scanning/codeql)
 # ScreenPro2
 
-## TL;DR
+## Introduction
+
+### TL;DR
 
 [**ReadTheDocs**](https://screenpro2.readthedocs.io) |
 [**PyPI**](https://pypi.org/project/ScreenPro2)
@@ -14,18 +16,45 @@
 ScreenPro2 enables perform flexible analysis on high-content CRISPR screening datasets. It has functionalities to process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
 
 ___
-## Introduction
-Functional genomics field is evolving rapidly and many more CRISPR screen platforms are now developed. Therefore, 
-it's important to have a standardized workflow to analyze the data from these screens. ScreenPro2 is provided to 
-enable researchers to easily process and analyze data from CRISPR screens. Currently, you need to have a basic background in programming (especially Python) to use ScreenPro2.
+<details>
+  <summary>Background</summary>
 
-ScreenPro2 is conceptually similar to the [**ScreenProcessing**](https://github.com/mhorlbeck/ScreenProcessing) pipeline but **ScreenPro2** is designed to be more modular, flexible, and extensible. Common CRISPR screen methods that we have implemented here are illustrated in a recent review paper:
+  Functional genomics field is evolving rapidly and many more CRISPR screen platforms are now developed. Therefore, 
+  it's important to have a standardized workflow to analyze the data from these screens. ScreenPro2 is provided to 
+  enable researchers to easily process and analyze data from CRISPR screens. Currently, you need to have a basic background in programming (especially Python) to use ScreenPro2.
 
-> From: [A new era in functional genomics screens](https://www.nature.com/articles/s41576-021-00409-w)
+  ScreenPro2 is conceptually similar to the [**ScreenProcessing**](https://github.com/mhorlbeck/ScreenProcessing) pipeline but **ScreenPro2** is designed to be more modular, flexible, and extensible. Common CRISPR screen methods that we have implemented here are illustrated in a recent review paper:
 
-> Fig. 1: Common types of CRISPR screening modalities indicating advances in CRISPR methods.
+  > From: [A new era in functional genomics screens](https://www.nature.com/articles/s41576-021-00409-w)
 
-> <img width="1000" alt="image" src="https://github.com/GilbertLabUCSF/ScreenPro2/assets/53412130/a39400ad-b24f-4859-b6e7-b4d5f269119c">
+  > Fig. 1: Common types of CRISPR screening modalities indicating advances in CRISPR methods.
+
+  > <img width="1000" alt="image" src="https://github.com/GilbertLabUCSF/ScreenPro2/assets/53412130/a39400ad-b24f-4859-b6e7-b4d5f269119c">
+
+</details>
+
+___
+
+<details>
+  <summary>Benchmarking</summary>
+
+  Benchmarking ScreenPro2 with other CRISPR screen analysis tools
+
+  ### More thoughtful NGS read trimming recovers more sgRNA counts
+
+  ### ScreenPro2 statistical analysis is more accurate than ScreenProcessing
+
+  ### ScreenPro2 is more flexible than ScreenProcessing
+
+  Not only does ScreenPro2 have more features than ScreenProcessing, but it is also more flexible. ScreenPro2 can process data from diverse CRISPR screen platforms and is designed to be modular to enable easy extension to custom CRISPR screen platforms or other commonly used platforms in addition to the ones currently implemented.
+
+  ### ScreenPro2 is faster than ScreenProcessing
+
+  Last but not least, ScreenPro2 runs faster than ScreenProcessing (thanks to [biobear](https://github.com/wheretrue/biobear)) for processing FASTQ files.
+  
+</details>
+
+___
 
 ## Installation
 ScreenPro2 is available on [PyPI](https://pypi.org/project/ScreenPro2/) and can be installed with pip:

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ ___
 ___
 
 <details>
-  <summary>Benchmarking</summary>
-  <div style="margin-top: 20px;"></div>
+  <summary>
+    Benchmarking
+  </summary>
   
   Benchmarking ScreenPro2 with other CRISPR screen analysis tools
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ Data analysis for CRISPR screens with NGS readouts can be broken down into three
 
 ### Step 1: FASTQ processing
 
+___
+
 <details>
-  <summary>command line interface (CLI)</summary>
+  <summary>Command Line Interface (CLI)</summary>
   <br>
   ScreenPro2 has a built-in command line interface (CLI) to process FASTQ files and generate counts.
 
@@ -134,71 +136,75 @@ Data analysis for CRISPR screens with NGS readouts can be broken down into three
 
 ___
 
-In addition to the CLI, ScreenPro2 has a built-in method to process FASTQ files and generate counts in Python.
-This method is implemented in the `ngs` module and relvent submodules. 
-A minor novelty here has enabled processing single, dual, or multiple sgRNA 
-CRISPR screens. Also, this approach can retain recombination events which can
-occur in dual or higher order sgRNA CRISPR screens.
+<details>
+  <summary>Python Package Usage</summary>
+  <br>
+  
+  In addition to the CLI, ScreenPro2 has a built-in method to process FASTQ files and generate counts in Python.
 
-Currently, `GuideCounter` class from the `ngs` module can process FASTQ files and generate counts for standard 
-CRISPR screens with [single](#dcas9-crisprai-single-sgrna-screens) or [dual](#dcas9-crisprai-dual-sgrna-screens) 
-guide design. 
+  This method is implemented in the `ngs` module and relvent submodules. 
+  A minor novelty here has enabled processing single, dual, or multiple sgRNA 
+  CRISPR screens. Also, this approach can retain recombination events which can
+  occur in dual or higher order sgRNA CRISPR screens.
 
-Here is a draft code to process FASTQ files and generate counts for an experiment with [CRISPRa/i-dual-sgRNA-screens](#dcas9-crisprai-dual-sgrna-screens):
+  Currently, `GuideCounter` class from the `ngs` module can process FASTQ files and generate counts for standard 
+  CRISPR screens with [single](#dcas9-crisprai-single-sgrna-screens) or [dual](#dcas9-crisprai-dual-sgrna-screens) 
+  guide design. 
 
-```python
-# Initialize the GuideCounter object
-counter = scp.GuideCounter(cas_type = 'cas9', library_type = 'single_guide_design')
+  Here is a draft code to process FASTQ files and generate counts for an experiment with [CRISPRa/i-dual-sgRNA-screens](#dcas9-crisprai-dual-sgrna-screens):
 
-# Load the reference library
-counter.load_library("<path-to-CRISPR-library-table>", sep = '\t', verbose = True, index_col=None)
+  ```python
+  # Initialize the GuideCounter object
+  counter = scp.GuideCounter(cas_type = 'cas9', library_type = 'single_guide_design')
 
-# Define the samples
-samples = [] 
-## `samples` is a list of sample ids in the experiment. 
-## Each sample id should match the sample name in the FASTQ files, i.e. <sample_id>.fastq.gz
+  # Load the reference library
+  counter.load_library("<path-to-CRISPR-library-table>", sep = '\t', verbose = True, index_col=None)
 
-# Process the FASTQ files and generate counts
-counter.get_counts_matrix(
-    fastq_dir = '<path-to-fastq-directory>',
-    samples = samples,
-    verbose = True
-)
-```
+  # Define the samples
+  samples = [] 
+  ## `samples` is a list of sample ids in the experiment. 
+  ## Each sample id should match the sample name in the FASTQ files, i.e. <sample_id>.fastq.gz
 
-Here is a draft code to process FASTQ files and generate counts for an experiment with [CRISPRa/i-dual-sgRNA-screens](#crispri-dual-sgrna-screens):
+  # Process the FASTQ files and generate counts
+  counter.get_counts_matrix(
+      fastq_dir = '<path-to-fastq-directory>',
+      samples = samples,
+      verbose = True
+  )
+  ```
+
+  Here is a draft code to process FASTQ files and generate counts for an experiment with [CRISPRa/i-dual-sgRNA-screens](#crispri-dual-sgrna-screens):
 
 
-```python
-# Initialize the Counter object
-counter = scp.GuideCounter(cas_type = 'dCas9', library_type = 'dual_guide_design')
+  ```python
+  # Initialize the Counter object
+  counter = scp.GuideCounter(cas_type = 'dCas9', library_type = 'dual_guide_design')
 
-# Load the reference library
-counter.load_library("<path-to-CRISPR-library-table>", sep = '\t', verbose = True, index_col=None)
+  # Load the reference library
+  counter.load_library("<path-to-CRISPR-library-table>", sep = '\t', verbose = True, index_col=None)
 
-# Define the samples
-samples = []
-## `samples` is a list of sample ids in the experiment.
-## Each sample id should match the sample name in the FASTQ files, i.e. <sample_id>_R[1,2].fastq.gz
+  # Define the samples
+  samples = []
+  ## `samples` is a list of sample ids in the experiment.
+  ## Each sample id should match the sample name in the FASTQ files, i.e. <sample_id>_R[1,2].fastq.gz
 
-# Process the FASTQ files and generate counts
-counter.get_counts_matrix(
-    fastq_dir = '<path-to-fastq-directory>',
-    samples = samples,
-    verbose = True
-)
-```
+  # Process the FASTQ files and generate counts
+  counter.get_counts_matrix(
+      fastq_dir = '<path-to-fastq-directory>',
+      samples = samples,
+      verbose = True
+  )
+  ```
 
-After this, you have `.counts_mat` calculated in the `GuideCounter` object.
+  After this, you have `.counts_mat` calculated in the `GuideCounter` object.
 
-___
+  To proceed, you need to create an `AnnData` object from the counts matrix and metadata. You can use the following code to create an `AnnData` object:
 
-To proceed, you need to create an `AnnData` object from the counts matrix and metadata. You can use the following code to create an `AnnData` object:
+  ```python
+  adata = counter.build_counts_anndata()
+  ```
 
-```python
-adata = counter.build_counts_anndata()
-```
-
+</details>
 ### Step 2: Phenotype calculation
 
 Once you have the counts, you can use ScreenPro2 `phenoscore` and `phenostats` modules to calculate the phenotype scores and statistics between screen arms.

--- a/screenpro/__init__.py
+++ b/screenpro/__init__.py
@@ -31,6 +31,6 @@ from .assays import PooledScreens, GImaps
 from .dashboard import DrugScreenDashboard
 
 
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 __author__ = "Abe Arab"
 __email__ = 'abea@arcinstitute.org' # "abarbiology@gmail.com"

--- a/screenpro/assays/__init__.py
+++ b/screenpro/assays/__init__.py
@@ -14,7 +14,7 @@ import scanpy as sc
 
 from ..phenoscore import (
     runPhenoScore, getPhenotypeData,
-    runDESeq, extractDESeqResults
+    runDESeq, extractDESeqResults,
 )
 from ..preprocessing import addPseudoCount, findLowCounts, normalizeSeqDepth
 from ..phenoscore._annotate import annotateScoreTable, hit_dict
@@ -300,6 +300,28 @@ class PooledScreens(object):
 
         return out
     
+    def getPhenotypeScores(self, phenotype_name, threshold, run_name='auto', **kwargs):
+        """
+        Get phenotype scores for a given phenotype_name
+
+        Args:
+            phenotype_name (str): name of the phenotype score
+            run_name (str): name of the phenotype calculation run to retrieve
+        """
+        if run_name == 'auto': run_name = self._auto_run_name()
+        
+        score_tag, _ = phenotype_name.split(':')
+
+        out = annotateScoreTable(
+            self.phenotypes[run_name]['results'][phenotype_name],
+            up_hit=hit_dict[score_tag]['up_hit'],
+            down_hit=hit_dict[score_tag]['down_hit'],
+            threshold=threshold,
+            **kwargs
+        )
+
+        return out
+
     def buildPhenotypeData(self, run_name='auto',db_rate_col='pop_doubling', **kwargs):
         if run_name == 'auto': run_name = self._auto_run_name()
         if run_name=='compare_reps':

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -113,7 +113,7 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, var_names='target', t
             test=test,
             ctrl_label=ctrl_label,
             growth_rate=growth_rate,
-        ).set_index(var_names)
+        )
         
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -114,7 +114,10 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, test,
             ctrl_label=ctrl_label,
             growth_rate=growth_rate,
         )
-    
+        
+        # rename pseudo genes in target column to `ctrl_label`
+        result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
+
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')
     

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -116,7 +116,7 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, test,
         )
         
         # rename pseudo genes in target column to `ctrl_label`
-        result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
+        result['target'] = result.rest_index()['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
 
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -113,7 +113,7 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, var_names='target', t
             test=test,
             ctrl_label=ctrl_label,
             growth_rate=growth_rate,
-        )
+        ).set_index(var_names)
         
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -55,11 +55,6 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, var_names='target', t
     # format result name
     result_name = f'{cond_test}_vs_{cond_ref}'
     print(f'\t{cond_test} vs {cond_ref}')
-
-    # check if collapse_var exists in adata.var.columns
-    if collapse_var not in [False, None]:
-        if collapse_var not in adat.var.columns:
-            raise ValueError(f'collapse_var "{collapse_var}" not found in adata.var.columns.')
     
     # set n_reps if not provided
     if n_reps == 'auto':
@@ -122,10 +117,14 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, var_names='target', t
         )
 
         # get best best transcript as lowest p-value for each target
-        if collapse_var:
-            result = getBestTargetByTSS(
-                score_df=result, target_col=collapse_var, pvalue_col=f'{test} pvalue'
-            )
+        if collapse_var not in [False, None]:
+            if collapse_var not in result.columns:
+                raise ValueError(f'collapse_var "{collapse_var}" not found in result columns.')
+            else:
+                result = getBestTargetByTSS(
+                    score_df=result, target_col=collapse_var, pvalue_col=f'{test} pvalue'
+                )
+                result.index.name = None
         
         # change target name to control label if it is a pseudo gene
         result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -116,7 +116,7 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, test,
         )
         
         # rename pseudo genes in target column to `ctrl_label`
-        result['target'] = result.rest_index()['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
+        result['target'] = result.reset_index()['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
 
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')

--- a/screenpro/phenoscore/__init__.py
+++ b/screenpro/phenoscore/__init__.py
@@ -127,7 +127,7 @@ def runPhenoScore(adata, cond_ref, cond_test, score_level, var_names='target', t
                 result.index.name = None
         
         # change target name to control label if it is a pseudo gene
-        result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
+        result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x).to_list()
         
     else:
         raise ValueError(f'score_level "{score_level}" not recognized. Currently, "compare_reps" and "compare_guides" are supported.')

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -72,6 +72,9 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
 
     adat = adata.copy()
 
+    # convert var_names to list
+    if not isinstance(var_names, list): var_names = [var_names]
+
     # get control values
     x_ctrl = df_cond_ref[adat.var.targetType.eq(ctrl_label)].to_numpy()
     y_ctrl = df_cond_test[adat.var.targetType.eq(ctrl_label)].to_numpy()

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -159,6 +159,12 @@ def averageBestN(scores, numToAverage):
     return np.mean(sorted(scores, key=abs, reverse=True)[:numToAverage])
 
 
+def scoreGeneByBestTranscript():
+    #TODO: implement this function
+    # https://github.com/mhorlbeck/ScreenProcessing/blob/0ee5192ecc17348665bd1387ddfa9037efb7964f/process_experiments.py#L311C5-L311C30
+    pass
+
+
 def generatePseudoGeneAnnData(adata, num_pseudogenes='auto', pseudogene_size='auto', ctrl_label='negative_control'):
     """Generate pseudogenes from negative control elements in the library.
 

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -105,7 +105,10 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     adj_p_values = multipleTestsCorrection(np.array(p_values))
 
     # get target information
-    targets_df = pd.DataFrame(targets); targets_df.columns = var_names
+    if type(var_names) == str:
+        targets_df = pd.DataFrame(targets, columns=[var_names])
+    elif type(var_names) == list:
+        targets_df = pd.DataFrame(targets, columns=var_names)
 
     # combine results into a dataframe
     result = pd.concat([

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -105,7 +105,7 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     adj_p_values = multipleTestsCorrection(np.array(p_values))
 
     # get target information
-    targets_df = pd.DataFrame(targets, columns=var_names)
+    targets_df = pd.DataFrame(targets); targets_df.columns = var_names
 
     # combine results into a dataframe
     result = pd.concat([

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -160,8 +160,10 @@ def averageBestN(scores, numToAverage):
 
 
 def scoreGeneByBestTranscript():
-    #TODO: implement this function
-    # https://github.com/mhorlbeck/ScreenProcessing/blob/0ee5192ecc17348665bd1387ddfa9037efb7964f/process_experiments.py#L311C5-L311C30
+    """
+    collapse the gene-transcript indices into a single score for a gene by best p-value
+    """
+    #TODO: implement this function, see #90
     pass
 
 

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -121,7 +121,7 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     result = pd.concat([targets_df, result], axis=1)
 
     # set index to var_names 
-    if len(var_names) > 1: 
+    if type(var_names) == list and len(var_names) > 1:
         result.index = result[var_names].agg('-'.join, axis=1)
     else:
         result.index = result[var_names]

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -55,17 +55,19 @@ def compareByReplicates(adata, df_cond_ref, df_cond_test, var_names='target', te
 
     # get adjusted p-values
     adj_p_values = multipleTestsCorrection(p_values)
-            
+
+    # get target information            
+    targets_df = adat.var[var_names].copy()
+
     # combine results into a dataframe
     result = pd.concat([
-        pd.Series(scores, name='score'),
-        pd.Series(p_values, name=f'{test} pvalue'),
-        pd.Series(adj_p_values, name='BH adj_pvalue'),
+        pd.Series(scores, index=adat.var.index, name='score'),
+        pd.Series(p_values, index=adat.var.index, name=f'{test} pvalue'),
+        pd.Series(adj_p_values, index=adat.var.index, name='BH adj_pvalue'),
     ], axis=1)
     
-    # set target names as index (for given `var_names`)
-    indices = pd.DataFrame(indices, columns=var_names)
-    result = pd.concat([indices, result], axis=1).set_index(var_names)
+    # add targets information 
+    result = pd.concat([targets_df, result], axis=1)
 
     return result
 
@@ -108,6 +110,9 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     # get adjusted p-values
     adj_p_values = multipleTestsCorrection(np.array(p_values))
 
+    # get target information
+    targets_df = pd.DataFrame(targets, columns=var_names)
+
     # combine results into a dataframe
     result = pd.concat([
         pd.Series(scores, name='score'),
@@ -115,9 +120,8 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
         pd.Series(adj_p_values, name='BH adj_pvalue'),
     ], axis=1)
 
-    # set target names as index (for given `var_names`)
-    indices = pd.DataFrame(targets, columns=var_names)
-    result = pd.concat([indices, result], axis=1).set_index(var_names)
+    # add targets information
+    result = pd.concat([targets_df, result], axis=1)
     
     return result
 

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -262,6 +262,9 @@ def generatePseudoGeneAnnData(adata, num_pseudogenes='auto', pseudogene_size='au
     Returns:
         AnnData: AnnData object with pseudogenes
     """
+    #TODO: check for `target` and `targetType` columns in adata.var
+    #TODO: add input arg to replace "target" and name it `target_col` or something similar
+    
     if pseudogene_size == 'auto':
         # sgRNA elements / target in the library
         pseudogene_size = int(adata.var[~adata.var.targetType.eq(ctrl_label)].groupby('target').size().mean())

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -102,18 +102,18 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
 
     # get adjusted p-values
     adj_p_values = multipleTestsCorrection(np.array(p_values))
-    
+
     # combine results into a dataframe
     result = pd.concat([
-        pd.Series(targets, index=targets, name='target'),
-        pd.Series(scores, index=targets, name='score'),
-        pd.Series(p_values, index=targets, name=f'{test} pvalue'),
-        pd.Series(adj_p_values, index=targets, name='BH adj_pvalue'),
+        pd.Series(scores, name='score'),
+        pd.Series(p_values, name=f'{test} pvalue'),
+        pd.Series(adj_p_values, name='BH adj_pvalue'),
     ], axis=1)
 
-    # rename pseudo genes in target column to `ctrl_label`
-    result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
-
+    # set target names as index (for given `var_names`)
+    indices = pd.DataFrame(targets, columns=var_names)
+    result = pd.concat([indices, result], axis=1).set_index(var_names)
+    
     return result
 
 

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -82,7 +82,7 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
 
     # group by target genes or pseudogenes to aggregate counts for score calculation
     for target_name, target_group in adat.var.groupby(var_names):
-        
+
         # calculate phenotype scores and p-values for each target group
         target_scores, target_p_values = scoreTargetGroup(
             target_group=target_group, 
@@ -102,7 +102,7 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
 
     # get adjusted p-values
     adj_p_values = multipleTestsCorrection(np.array(p_values))
-
+    
     # combine results into a dataframe
     result = pd.concat([
         pd.Series(targets, index=targets, name='target'),

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -124,7 +124,10 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     result = pd.concat([targets_df, result], axis=1)
 
     # set index
-    result.index = result[var_names].apply(lambda x: '-'.join(x), axis=1)
+    result.index = result[var_names].apply(lambda x: '-'.join(x) if 'pseudo' not in x else x[0])
+
+    # change target name to control label if it is a pseudo gene
+    result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
     
     return result
 

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -29,9 +29,6 @@ def compareByReplicates(adata, df_cond_ref, df_cond_test, var_names='target', te
     """
     adat = adata.copy()
 
-    # convert var_names to list
-    if not isinstance(var_names, list): var_names = [var_names]
-
     # convert to numpy arrays
     x = df_cond_ref.to_numpy()
     y = df_cond_test.to_numpy()
@@ -75,9 +72,6 @@ def compareByReplicates(adata, df_cond_ref, df_cond_test, var_names='target', te
 def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names='target', test='ttest', ctrl_label='negative_control', growth_rate=1):
 
     adat = adata.copy()
-
-    # convert var_names to list
-    if not isinstance(var_names, list): var_names = [var_names]
 
     # get control values
     x_ctrl = df_cond_ref[adat.var.targetType.eq(ctrl_label)].to_numpy()

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -123,8 +123,11 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     # add targets information
     result = pd.concat([targets_df, result], axis=1)
 
-    # set index
-    result.index = result[var_names].apply(lambda x: '-'.join(x) if 'pseudo' not in x else x[0])
+    # set index to var_names 
+    if len(var_names) > 1: 
+        result.index = result[var_names].agg('-'.join, axis=1)
+    else:
+        result.index = result[var_names]
 
     # change target name to control label if it is a pseudo gene
     result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -129,9 +129,6 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
     else:
         result.index = result[var_names]
 
-    # change target name to control label if it is a pseudo gene
-    result['target'] = result['target'].apply(lambda x: ctrl_label if 'pseudo' in x else x)
-    
     return result
 
 
@@ -217,12 +214,14 @@ def averageBestN(scores, numToAverage):
     return np.mean(sorted(scores, key=abs, reverse=True)[:numToAverage])
 
 
-def scoreGeneByBestTranscript():
+def getBestTargetByTSS(score_df,target_col,pvalue_col):
     """
     collapse the gene-transcript indices into a single score for a gene by best p-value
     """
     #TODO: implement this function, see #90
-    pass
+    return score_df.groupby(target_col).apply(
+        lambda x: x.loc[x[pvalue_col].idxmin()]
+    )
 
 
 def scoreTargetGroup(target_group, df_cond_ref, df_cond_test, x_ctrl, y_ctrl, test='ttest', growth_rate=1, keep_top_n=None):

--- a/screenpro/phenoscore/delta.py
+++ b/screenpro/phenoscore/delta.py
@@ -122,6 +122,9 @@ def compareByTargetGroup(adata, df_cond_ref, df_cond_test, keep_top_n, var_names
 
     # add targets information
     result = pd.concat([targets_df, result], axis=1)
+
+    # set index
+    result.index = result[var_names].apply(lambda x: '-'.join(x), axis=1)
     
     return result
 

--- a/screenpro/phenoscore/evaluate.py
+++ b/screenpro/phenoscore/evaluate.py
@@ -1,0 +1,66 @@
+## Copyright (c) 2022-2024 ScreenPro2 Development Team.
+## All rights reserved.
+## Gilbart Lab, UCSF / Arc Institute.
+## Multi-Omics Tech Center, Arc Insititue.
+##
+## courtesy Tyler Fair (@tdfair), M. Horlbeck, (@mhorlbeck)
+
+'''
+evaluate module: evaluate essentiality detection performance
+'''
+
+import numpy as np
+from sklearn import metrics
+from sklearn.metrics import precision_recall_curve
+import matplotlib.lines as mlines
+
+
+def calcROC(df_in, essential, nonessential, score_col, target_col='target', verbose=False):
+    df = df_in.copy()
+    df[target_col] = df[target_col].str.split('-').str[0]
+    
+    # AUC-ROC
+    df['DepMap'] = np.nan
+    df.loc[df[target_col].isin(essential),'DepMap'] = 'essential'
+    df.loc[df[target_col].isin(nonessential),'DepMap'] = 'non_essential'
+    
+    y_true = df[df['DepMap'].notna()]['DepMap']
+    y_scores = df[df['DepMap'].notna()][score_col]
+    
+    fpr, tpr, thresholds = metrics.roc_curve(y_true, y_scores, pos_label='non_essential')
+    
+    if verbose: print('ROC-AUC score:', metrics.roc_auc_score(y_true, y_scores))
+    
+    return fpr, tpr
+
+
+def calcPR(df_in, truePos, trueNeg, score_col, target_col='target', ascending=True, verbose=False):
+
+    df = df_in.copy()
+
+    scoreList = df.set_index(target_col)[score_col]
+
+    truePos = truePos.intersection(scoreList.index)
+    trueNeg = trueNeg.intersection(scoreList.index)
+    
+    cumulativeTup = [(0,1,np.nan)]
+    cumulativeTP = 0.0
+    cumulativeFP = 0.0
+    
+    tup_cross95 = None
+    
+    for gene, fold_change in scoreList.sort_values(inplace=False, ascending=ascending).items():
+        if gene in truePos or gene in trueNeg:
+            if gene in truePos:
+                cumulativeTP += 1
+
+            elif gene in trueNeg:
+                cumulativeFP += 1
+
+            cumulativeTup.append((cumulativeTP / len(truePos), cumulativeTP / (cumulativeTP + cumulativeFP), fold_change))
+    
+    tup_cross95 = [cross95 for cross95 in cumulativeTup[::-1] if cross95[1] >= 0.95][0]
+    
+    if verbose: print('Precision-Recall AUC:', tup_cross95)
+    
+    return cumulativeTup, tup_cross95


### PR DESCRIPTION
- update README format and content
- minor bug fixes
- draft a new sub-module in `phenoscore` called `evaluate`
  - related to #4
  - includes functions for calculating ROC-AUC and Precision-Recall AUC scores. 
  - courtesy Tyler Fair (@tdfair) and M. Horlbeck, (@mhorlbeck)
- get best best transcript as lowest p-value for each target
  - close #85
  - close #90