### PR TITLE
address bugs in processing flow cytometry based screens

### DIFF
--- a/screenpro/__init__.py
+++ b/screenpro/__init__.py
@@ -31,6 +31,6 @@ from .assays import PooledScreens, GImaps
 from .dashboard import DrugScreenDashboard
 
 
-__version__ = "0.4.15"
+__version__ = "0.4.16"
 __author__ = "Abe Arab"
 __email__ = 'abea@arcinstitute.org' # "abarbiology@gmail.com"

--- a/screenpro/assays/__init__.py
+++ b/screenpro/assays/__init__.py
@@ -286,6 +286,20 @@ class PooledScreens(object):
             run_name (str): name for the phenotype calculation run
             **kwargs: additional arguments to pass to runPhenoScore
         """
+        if not run_name: run_name = score_level
+        if run_name in self.phenotypes.keys():
+            raise ValueError(f"Phenotype calculation run '{run_name}' already exists in self.phenoypes!")
+        else:
+            self.phenotypes[run_name] = {}
+            self.phenotypes[run_name]['config'] = {
+                'method':'ScreenPro2 - phenoscore',
+                'low_bin':low_bin,
+                'high_bin':high_bin,
+                'test':self.test,
+                'score_level':score_level,
+            }
+            self.phenotypes[run_name]['results'] = {}
+            
         # calculate phenotype scores
         delta_name, delta = runPhenoScore(
             self.adata, cond_ref=low_bin, cond_test=high_bin, n_reps=self.n_reps,
@@ -293,15 +307,8 @@ class PooledScreens(object):
             **kwargs
         )
 
-        if not run_name: run_name = score_level
-        # save all results into a multi-index dataframe
-        self.phenotypes[run_name] = pd.concat({
-            f'delta:{delta_name}': delta
-        }, axis=1)
-
-        # save phenotype name for reference
-        self._add_phenotype_results(f'delta:{delta_name}')
-
+        self._add_phenotype_results(run_name, f'delta:{delta_name}', delta)
+        
     def listPhenotypeScores(self, run_name='auto'):
         """
         List available phenotype scores for a given run_name

--- a/screenpro/phenoscore/_annotate.py
+++ b/screenpro/phenoscore/_annotate.py
@@ -17,6 +17,10 @@ hit_dict = {
     'rho':{
         'up_hit':'resistance_hit', 
         'down_hit':'sensitivity_hit'
+    },
+    'delta':{
+        'up_hit':'up_hit',
+        'down_hit':'down_hit'
     }
 }
 


### PR DESCRIPTION
When running `screen.calculateFlowBasedScreen`, I encountered this Type Error: `PooledScreens._add_phenotype_results() missing 2 required positional arguments: 'phenotype_name' and 'phenotype_table’`. I amended this method to make it similar to the `calculateDrugFlowBasedScreen` structure due to previous changes in the `PooledScreens._add_phenotype_results()` method.

Also, to get the `drawVolcano` method to work for flow-based screens, I added the `delta` parameter to the hits dictionary so that the annotations worked properly.